### PR TITLE
feat(k8s.csh): add Dataverse admin API key to config values

### DIFF
--- a/k8s/central-search-hub/Chart.yaml
+++ b/k8s/central-search-hub/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/central-search-hub/templates/backend.yaml
+++ b/k8s/central-search-hub/templates/backend.yaml
@@ -26,6 +26,11 @@ spec:
             value: {{ .Values.api.dataverse_oidc_id }}
           - name: BACKEND_MODE
             value: {{ .Values.api.backend_mode }}
+          - name: DATAVERSE_ADMIN_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-backend-dv-admin-api-key-secret
+                key: token
           - name: API_TOKEN
             valueFrom:
               secretKeyRef:
@@ -69,3 +74,13 @@ metadata:
 type: Opaque
 data:
   token: {{ default "" .Values.api.default_token | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-backend-dv-admin-api-key-secret
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+  token: {{ default "" .Values.api.dataverse_admin_api_key | b64enc | quote }}

--- a/k8s/central-search-hub/values.yaml
+++ b/k8s/central-search-hub/values.yaml
@@ -2,6 +2,7 @@ api:
   backend_mode:
   dataverse_oidc_id:
   dataverse_host:
+  dataverse_admin_api_key:
 ingress:
   dns:
   enableSSL: false


### PR DESCRIPTION
This is required for creating new Dataverse user accounts upon first login at the Study Hub.