### PR TITLE
fix(k8s.dataverse): set default container for solr

### DIFF
--- a/k8s/dataverse/Chart.yaml
+++ b/k8s/dataverse/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/dataverse/templates/solr.yaml
+++ b/k8s/dataverse/templates/solr.yaml
@@ -75,6 +75,7 @@ spec:
         app.kubernetes.io/version: "9.5.0"
         app.kubernetes.io/component: solr
         app.kubernetes.io/part-of: dataverse
+        kubectl.kubernetes.io/default-container: "solr"
     spec:
       securityContext:
         fsGroup: 8983


### PR DESCRIPTION
> The value of the annotation is the container name that is default for this Pod. For example, kubectl logs or kubectl exec without -c or --container flag will use this default container.

https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container

when running `kubectl logs` or `exec`, usually you are interested in the `solr` container, not `dataverse-solr-config`

cc @julian-schneider