### PR TITLE
fix(k8s.dataverse): prevent merging list of PID providers with sample values

### DIFF
--- a/k8s/dataverse/Chart.yaml
+++ b/k8s/dataverse/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.4
+version: 0.10.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/dataverse/templates/dataverse-pod.yaml
+++ b/k8s/dataverse/templates/dataverse-pod.yaml
@@ -100,19 +100,24 @@ spec:
             - name: DATAVERSE_DB_VALIDATION_CLASSNAME
               value: "org.glassfish.api.jdbc.validation.PostgresConnectionValidation"
             - name: DATAVERSE_PID_PROVIDERS
-              value: {{ quote (join "," (keys .Values.dataverse.pid_providers)) }}
+              {{- $pidProviderNames := list -}}
+              {{- range $pidProvider := .Values.dataverse.pid_providers -}}
+                {{- $pidProviderNames = append $pidProviderNames $pidProvider.name -}}
+              {{- end }}
+              value: {{ quote (join "," $pidProviderNames) }}
             - name: DATAVERSE_PID_DEFAULT_PROVIDER
               value: {{ .Values.dataverse.default_pid_provider }}
-          {{- range $provider_key, $provider_vals := .Values.dataverse.pid_providers -}}
-            {{- range $key, $val := $provider_vals }}
+          {{- range .Values.dataverse.pid_providers -}}
+            {{- $pid_provider := . }}
+            {{- range $key, $val := . }}
               {{- if eq $key "datacite_password" }}
-            - name: DATAVERSE_PID_{{ upper $provider_key }}_{{ upper $key }}
+            - name: DATAVERSE_PID_{{ upper $pid_provider.name }}_{{ upper $key }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $.Release.Name }}-dataverse-pid-provider-secret
-                  key: {{ $provider_key }}-datacite-password
+                  key: {{ $pid_provider.name }}-datacite-password
               {{- else }}
-            - name: DATAVERSE_PID_{{ upper $provider_key }}_{{ upper $key }}
+            - name: DATAVERSE_PID_{{ upper $pid_provider.name }}_{{ upper $key }}
               value: {{ $val | quote }}
               {{- end }}
             {{- end -}}

--- a/k8s/dataverse/templates/dataverse-pod.yaml
+++ b/k8s/dataverse/templates/dataverse-pod.yaml
@@ -244,8 +244,8 @@ metadata:
   name: {{ .Release.Name }}-dataverse-pid-provider-secret
 type: Opaque
 data:
-  {{- range $key, $val := .Values.dataverse.pid_providers }}
-    {{- if hasKey $val "datacite_password" }}
-  {{ $key }}-datacite-password: {{ $val.datacite_password | b64enc | quote }}
+  {{- range .Values.dataverse.pid_providers }}
+    {{- if hasKey . "datacite_password" }}
+  {{ .name }}-datacite-password: {{ .datacite_password | b64enc | quote }}
     {{- end }}
   {{- end }}

--- a/k8s/dataverse/values.yaml
+++ b/k8s/dataverse/values.yaml
@@ -19,7 +19,7 @@ dataverse:
       memory: "1Gi"
   default_pid_provider: "permalink"
   pid_providers:
-    permalink:
+    - name: permalink
       type: "perma"
       authority:
       permalink_base_url:


### PR DESCRIPTION
fixes bug introduced by #38 

The PID provider values in values.yaml were intended as sample values to be overwritten by custom configurations passed with the -f flag during Dataverse deployment.

However, Helm merges dictionaries by default, causing the sample PID provider values to end up in the deployed config. This fix addresses the issue by providing PID providers as a list, which Helm does not merge.

cc @julian-schneider 