### PR TITLE
feat(k8s): add Helm chart for publish job

### DIFF
--- a/k8s/dataverse_jobs/publish_job/Chart.yaml
+++ b/k8s/dataverse_jobs/publish_job/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: dataverse_publish_job
+description: A job to publish datasets in a Dataverse
+type: application
+version: 0.1.0
+appVersion: "6.6.0"

--- a/k8s/dataverse_jobs/publish_job/templates/publish_job.yaml
+++ b/k8s/dataverse_jobs/publish_job/templates/publish_job.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-dataverse-publish-job
+spec:
+  template:
+    spec:
+      containers:
+        - name: dataverse-scripts
+          image: ghcr.io/nfdi4health/csh-etl-pipeline:latest
+          env:
+            - name: DATAVERSE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-dataverse-publish-job-secret
+                  key: DATAVERSE_API_KEY
+          command:
+            - "python"
+            - "-u" # unbuffered, so logs are immediately flushed
+            - "scripts/publish_all_datasets.py"
+            - "-d http://{{ .Values.dataverse.name }}-svc:8080"
+            - "-k"
+            - "$(DATAVERSE_API_KEY)"
+            - "-t"
+            - "{{ .Values.dataverse.publish_type }}"
+            - "-c"
+            - "{{ .Values.dataverse.collections }}"
+      restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-dataverse-publish-job-secret
+data:
+  DATAVERSE_API_KEY: {{ .Values.dataverse.api_key | b64enc | quote }}

--- a/k8s/dataverse_jobs/publish_job/values.yaml
+++ b/k8s/dataverse_jobs/publish_job/values.yaml
@@ -1,0 +1,5 @@
+dataverse:
+  name: ""
+  api_key: ""
+  publish_type: "updatecurrent" # "major", "minor" or "updatecurrent"
+  collections: "DRKS" # separated by spaces


### PR DESCRIPTION
adds a Helm chart for deploying a Kubernetes job which publishes datasets in a Dataverse instance

related issue: https://github.com/nfdi4health/csh-ui/issues/1181

related PR: https://github.com/nfdi4health/csh-etl-pipeline/pull/37