### PR TITLE
Update to Dataverse v6.9

### DIFF
--- a/k8s/dataverse/Chart.yaml
+++ b/k8s/dataverse/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.0
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.8.0"
+appVersion: "6.9.0"

--- a/k8s/dataverse/persona/nfdi4health/init.sh
+++ b/k8s/dataverse/persona/nfdi4health/init.sh
@@ -102,6 +102,7 @@ for ROLE_FILE in "${LOCAL_ROLES[@]}"; do
     echo
   else
     # On any error except 404, fail the script
+    echo "ERR: Getting role $ALIAS failed with $GET_RES"
     exit 1
   fi
 

--- a/k8s/dataverse/persona/nfdi4health/init.sh
+++ b/k8s/dataverse/persona/nfdi4health/init.sh
@@ -46,6 +46,10 @@ echo "Setting file upload limit to 5Gi"
 curl -X PUT -d 5368709120 "${DATAVERSE_URL}/api/admin/settings/:MaxFileUploadSizeInBytes"
 echo
 
+echo "Hiding email addresses from exports"
+curl -X PUT -d true "${DATAVERSE_URL}/api/admin/settings/:ExcludeEmailFromExport"
+echo
+
 echo "Upload licenses"
 #curl -X POST -H "Content-Type: application/json" -H "X-Dataverse-key:$DATAVERSE_API_KEY" $DATAVERSE_HOST/api/licenses --upload-file license-CC0-1.0.json
 # Find all licence files

--- a/k8s/dataverse/templates/dataverse-pod.yaml
+++ b/k8s/dataverse/templates/dataverse-pod.yaml
@@ -239,7 +239,7 @@ spec:
             - |
               git clone https://github.com/GlobalDataverseCommunityConsortium/dataverse-language-packs.git /tmp/dataverse-language-packs
               cd /tmp/dataverse-language-packs
-              git checkout dataverse-v6.8
+              git checkout dataverse-v6.9
               mkdir /dv/lang
               {{- range .Values.dataverse.multiple_language_support.languages }}
               cp {{ . }}/*.properties /dv/lang

--- a/k8s/dataverse/values.yaml
+++ b/k8s/dataverse/values.yaml
@@ -43,5 +43,5 @@ solr:
     requests:
       memory: "1Gi"
 images:
-  backend: ghcr.io/nfdi4health/csh-ui/dataverse:6.8-fork-v1
-  configbaker: gdcc/configbaker:6.8-noble
+  backend: ghcr.io/nfdi4health/csh-ui/dataverse:6.9-nfdi4health-v1
+  configbaker: gdcc/configbaker:6.9-noble

--- a/k8s/dataverse/values.yaml
+++ b/k8s/dataverse/values.yaml
@@ -43,5 +43,5 @@ solr:
     requests:
       memory: "1Gi"
 images:
-  backend: ghcr.io/nfdi4health/csh-ui/dataverse:6.9-nfdi4health-v1
+  backend: ghcr.io/nfdi4health/csh-ui/dataverse:6.9-nfdi4health-v8
   configbaker: gdcc/configbaker:6.9-noble


### PR DESCRIPTION
## Upgrade instructions

- Since the `ExcludeEmailFromExport` setting was changed, all datasets need to be re-exported: `curl http://localhost:8080/api/admin/metadata/reExportAll`
- If database settings cannot be loaded (check with `/api/admin/settings` => should not return `{}`), you might need to update the database table: `update setting set lang = '' where lang is null;`