### PR TITLE
fix(k8s.dataverse): remove dynamic appVersion label from StatefulSet selectors

### DIFF
--- a/k8s/dataverse/Chart.yaml
+++ b/k8s/dataverse/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.19.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/dataverse/templates/dataverse-pod.yaml
+++ b/k8s/dataverse/templates/dataverse-pod.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: dataverse
     app.kubernetes.io/instance: dataverse-{{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: dataverse
     app.kubernetes.io/part-of: dataverse
 spec:
@@ -25,7 +24,6 @@ spec:
   selector:
     app.kubernetes.io/name: dataverse
     app.kubernetes.io/instance: dataverse-{{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: dataverse
     app.kubernetes.io/part-of: dataverse
 ---
@@ -36,7 +34,6 @@ metadata:
   labels:
     app.kubernetes.io/name: dataverse
     app.kubernetes.io/instance: dataverse-{{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: dataverse
     app.kubernetes.io/part-of: dataverse
 spec:
@@ -45,7 +42,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: dataverse
       app.kubernetes.io/instance: dataverse-{{ .Release.Name }}
-      app.kubernetes.io/version: {{ .Chart.AppVersion }}
       app.kubernetes.io/component: dataverse
       app.kubernetes.io/part-of: dataverse
   template:
@@ -53,7 +49,6 @@ spec:
       labels:
         app.kubernetes.io/name: dataverse
         app.kubernetes.io/instance: dataverse-{{ .Release.Name }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: dataverse
         app.kubernetes.io/part-of: dataverse
     spec:


### PR DESCRIPTION
#### Why this change was made
Updating the `appVersion` in `Chart.yaml` previously caused Helm upgrades to fail with a "Forbidden: updates to statefulset spec" error. This happened because Kubernetes does not allow modifications to the `selector` field of an existing `StatefulSet`. Since the selector included the dynamic `app.kubernetes.io/version` label, any version bump triggered an invalid update request.