### PR TITLE
fix(k8s.dataverse): remove unnecessary permission from member role in nfdi4health persona

### DIFF
--- a/k8s/dataverse/Chart.yaml
+++ b/k8s/dataverse/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/dataverse/persona/nfdi4health/roles/role-member.json
+++ b/k8s/dataverse/persona/nfdi4health/roles/role-member.json
@@ -4,7 +4,6 @@
     "description":"Can view, but not edit or delete, an unpublished entry.",
     "permissions":[
         "ViewUnpublishedDataset",
-        "ViewUnpublishedDataverse",
         "DownloadFile"
     ]
 }


### PR DESCRIPTION
The permission caused a bug in the preview URL feature (https://github.com/nfdi4health/csh-ui/issues/1738).

When creating a preview URL, the "Member" role is assigned for access via the preview URL token.

Assigning a role requires that the assigning user has all the permissions of the assigned role (to prevent privilege escalation, you cannot assign anyone permissions that you don't have yourself). [2]

None of our non-curator users have the "ViewUnpublishedDataverse" permission, so assigning the "Member" role failed. Since we don't need the permission, I have simply removed it for now.

To update the role in a running Dataverse instance:

`curl -X PUT -H "Content-type:application/json" --upload-file "persona/nfdi4health/roles/role-member.json" "$DATAVERSE_URL/api/admin/roles/$MEMBER_ROLE_ID"`

[1] https://github.com/IQSS/dataverse/blob/develop/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/CreatePrivateUrlCommand.java#L57
[2] https://github.com/IQSS/dataverse/blob/develop/src/main/java/edu/harvard/iq/dataverse/engine/command/impl/AssignRoleCommand.java#L107