### PR TITLE
Added cronjob limit arg for etl pipeline

### DIFF
--- a/k8s/etl-pipeline/Chart.yaml
+++ b/k8s/etl-pipeline/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: etl-pipeline
 description: A Helm chart for the ETL pipeline cronjobs
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
+++ b/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
@@ -47,7 +47,7 @@ spec:
                     SINCE_ARG="--since $LAST_SUCCESS_DATE";
                     echo "Found last successful load from $LAST_SUCCESS_DATE, using $SINCE_ARG";
                   fi;
-                  python3 -u etljobs/extract/extract_{{ lower .Values.source }}_data.py --temp-dir /tmp/extract --output s3://$EXTRACT_PATH $SINCE_ARG
+                  python3 -u etljobs/extract/extract_{{ lower .Values.source }}_data.py --temp-dir /tmp/extract --output s3://$EXTRACT_PATH {{ if .Values.extract.limit }}--limit {{ .Values.extract.limit }} {{ end }}$SINCE_ARG
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/k8s/etl-pipeline/values.yaml
+++ b/k8s/etl-pipeline/values.yaml
@@ -38,3 +38,6 @@ spark:
     load:
       threads: 8
       skipCollectionUpdates: true
+
+extract:
+  limit: ""


### PR DESCRIPTION
## 📝 Description

🎫 Closes: #

Added an optional extract.limit value for ETL cronjobs to support limited test runs of the extract step.

---

## 🔧 Changes

- Added optional --limit argument to ETL extract cronjob command
- Added configurable extract.limit value to values.yaml
- Allows running smaller ETL test runs without changing templates manually

---

## ✅ Checklist

- [ ] 📝 Version number in Helm's `Chart.yaml` was updated (if needed)
- [ ] 📚 Documentation was updated (if needed)
