### PR TITLE
feat: add optional htpasswd for basic auth to frontend deployment

### DIFF
--- a/k8s/central-search-hub/Chart.yaml
+++ b/k8s/central-search-hub/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/central-search-hub/templates/frontend.yaml
+++ b/k8s/central-search-hub/templates/frontend.yaml
@@ -30,6 +30,17 @@ spec:
             value: {{ .Values.frontend.userback_access_token }}
         ports:
           - containerPort: 80
+{{- if not (empty .Values.frontend.basicAuth.htpasswd) }}
+        volumeMounts:
+          - mountPath: /etc/nginx/.htpasswd
+            name: frontend-basic-auth
+            subPath: .htpasswd
+            readOnly: true
+      volumes:
+        - name: frontend-basic-auth
+          secret:
+            secretName: {{ .Release.Name }}-frontend-basic-auth
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -42,3 +53,13 @@ spec:
       targetPort: 80
   selector:
     name: {{ .Release.Name }}-frontend
+{{- if not (empty .Values.frontend.basicAuth.htpasswd) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-frontend-basic-auth
+type: Opaque
+stringData:
+  .htpasswd: {{ .Values.frontend.basicAuth.htpasswd | quote }}
+{{- end }}

--- a/k8s/central-search-hub/values.yaml
+++ b/k8s/central-search-hub/values.yaml
@@ -6,6 +6,8 @@ api:
   unblock_key:
 frontend:
   userback_access_token:
+  basicAuth:
+    htpasswd:
 ingress:
   dns:
   enableSSL: false


### PR DESCRIPTION
## 📝 Description

This PR adds optional htpasswd authentication to Study Hub frontend deployments.

---

## ✅ Checklist

- [x] 📝 Version number in Helm's `Chart.yaml` was updated (if needed)
- [ ] 📚 Documentation was updated (if needed)
