### PR TITLE
feat: integrate DRKS reference scraping into ETL pipeline

### DIFF
--- a/k8s/etl-pipeline/Chart.yaml
+++ b/k8s/etl-pipeline/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: etl-pipeline
 description: A Helm chart for the ETL pipeline cronjobs
 type: application
-version: 1.0.3
+version: 1.0.4

--- a/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
+++ b/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
@@ -113,6 +113,29 @@ spec:
                   echo "Waiting for s3://$EXTRACT_PATH...";
                   until aws s3 ls s3://$EXTRACT_PATH/_SUCCESS --endpoint-url=$AWS_ENDPOINT_URL; 
                   do sleep 10; done
+{{ if eq .Values.source "DRKS" }}
+            - name: grobid
+              image: lfoppiano/grobid:0.7.2
+              restartPolicy: Always
+              env:
+                - name: JAVA_OPTS
+                  value: "-Xms1g -Xmx3g"
+              ports:
+                - containerPort: 8070
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8070
+                initialDelaySeconds: 15
+                periodSeconds: 5
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: "4Gi"
+                limits:
+                  cpu: "2"
+                  memory: "6Gi"
+{{ end }}
           containers:
             - name: spark-submit
               image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
@@ -191,28 +214,6 @@ spec:
                   --job-args
                   s3a://$EXTRACT_PATH
                   s3a://$TRANSFORM_PATH
-{{ if eq .Values.source "DRKS" }}
-            - name: grobid
-              image: lfoppiano/grobid:0.7.2
-              env:
-                - name: JAVA_OPTS
-                  value: "-Xms1g -Xmx3g"
-              ports:
-                - containerPort: 8070
-              readinessProbe:
-                httpGet:
-                  path: /
-                  port: 8070
-                initialDelaySeconds: 15
-                periodSeconds: 5
-              resources:
-                requests:
-                  cpu: "1"
-                  memory: "4Gi"
-                limits:
-                  cpu: "2"
-                  memory: "6Gi"
-{{ end }}
 ---
 {{ end -}}
 {{ if and (eq .Values.persona "nfdi4health") .Values.stages.load.substages.submit.enabled -}}

--- a/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
+++ b/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
@@ -170,13 +170,6 @@ spec:
                 - -c
               args:
                 - >
-{{ if eq .Values.source "DRKS" }}
-                  until curl -sf http://localhost:8070/ > /dev/null;
-                  do
-                    echo "Waiting for GROBID...";
-                    sleep 5;
-                  done;
-{{ end }}
                   {{- if .Values.stages.transform.arguments.inputPath }}
                   EXTRACT_PATH="${S3_PATH}/{{ .Values.stages.transform.arguments.inputPath }}";
                   {{- else }}
@@ -191,6 +184,13 @@ spec:
                     echo "Parquet file already exists, skipping."
                     exit 0
                   fi;
+{{ if eq .Values.source "DRKS" }}
+                  until curl -sf http://localhost:8070/ > /dev/null;
+                  do
+                    echo "Waiting for GROBID...";
+                    sleep 5;
+                  done;
+{{ end }}
                   /opt/spark/bin/spark-submit
                   --master
                   local[*]

--- a/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
+++ b/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
@@ -58,7 +58,12 @@ spec:
                   {{- else }}
                   echo "Incremental update disabled, running full extract.";
                   {{- end }}
-                  python3 -u -m etljobs.extract.extract_data --data-source {{ lower .Values.source }} {{ if ne (print .Values.stages.extract.arguments.delay) "" }}--delay {{ .Values.stages.extract.arguments.delay }} {{ end }} {{ if ne (print .Values.stages.extract.arguments.workers) "" }}--workers {{ .Values.stages.extract.arguments.workers }} {{ end }}--temp-dir /tmp/extract --output s3://$EXTRACT_PATH {{ if .Values.stages.extract.arguments.limit }}--limit {{ .Values.stages.extract.arguments.limit }} {{ end }}$SINCE_ARG
+                  python3 -u -m etljobs.extract.extract_data --data-source {{ lower .Values.source }} {{ if ne (print .Values.stages.extract.arguments.delay) "" }}--delay {{ .Values.stages.extract.arguments.delay }} {{ end }} {{ if ne (print .Values.stages.extract.arguments.workers) "" }}--workers {{ .Values.stages.extract.arguments.workers }} {{ end }}--temp-dir /tmp/extract --output s3://$EXTRACT_PATH {{ if .Values.stages.extract.arguments.limit }}--limit {{ .Values.stages.extract.arguments.limit }} {{ end }}$SINCE_ARG;
+                  if aws s3 ls s3://${EXTRACT_PATH}/_SUCCESS --endpoint-url=$AWS_ENDPOINT_URL; then
+                    exit 0
+                  else
+                    exit 1
+                  fi;
 ---
 {{ end -}}
 {{ if and (eq .Values.persona "nfdi4health") .Values.stages.transform.enabled -}}

--- a/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
+++ b/k8s/etl-pipeline/templates/persona/nfdi4health/cronjobs.yaml
@@ -147,6 +147,13 @@ spec:
                 - -c
               args:
                 - >
+{{ if eq .Values.source "DRKS" }}
+                  until curl -sf http://localhost:8070/ > /dev/null;
+                  do
+                    echo "Waiting for GROBID...";
+                    sleep 5;
+                  done;
+{{ end }}
                   {{- if .Values.stages.transform.arguments.inputPath }}
                   EXTRACT_PATH="${S3_PATH}/{{ .Values.stages.transform.arguments.inputPath }}";
                   {{- else }}
@@ -184,6 +191,28 @@ spec:
                   --job-args
                   s3a://$EXTRACT_PATH
                   s3a://$TRANSFORM_PATH
+{{ if eq .Values.source "DRKS" }}
+            - name: grobid
+              image: lfoppiano/grobid:0.7.2
+              env:
+                - name: JAVA_OPTS
+                  value: "-Xms1g -Xmx3g"
+              ports:
+                - containerPort: 8070
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8070
+                initialDelaySeconds: 15
+                periodSeconds: 5
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: "4Gi"
+                limits:
+                  cpu: "2"
+                  memory: "6Gi"
+{{ end }}
 ---
 {{ end -}}
 {{ if and (eq .Values.persona "nfdi4health") .Values.stages.load.substages.submit.enabled -}}


### PR DESCRIPTION
## 📝 Description

🎫 Related to: https://github.com/nfdi4health/csh-ui/issues/1873

This PR adds support for an enrichment substep of the transform step for DRKS studies.

---

## 🔧 Changes

- Added grobid container to run along the transform container for DRKS jobs.

---

## ✅ Checklist

- [x] 📝 Version number in Helm's `Chart.yaml` was updated (if needed)
- [ ] 📚 Documentation was updated (if needed)
