### PR TITLE
feat: add server-injected SEO metadata to details pages

### DIFF
--- a/k8s/central-search-hub/Chart.yaml
+++ b/k8s/central-search-hub/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/central-search-hub/templates/frontend_seo.yaml
+++ b/k8s/central-search-hub/templates/frontend_seo.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.frontend.seoRenderer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-frontend-seo
+spec:
+  replicas: {{ .Values.frontend.seoRenderer.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-frontend-seo
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-frontend-seo
+    spec:
+      containers:
+        - name: frontend-seo
+          image: {{ .Values.images.seoRenderer }}
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+            - name: INDEX_HTML_PATH
+              value: "/app/build/index.html"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{ toYaml .Values.frontend.seoRenderer.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-frontend-seo
+spec:
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  selector:
+    name: {{ .Release.Name }}-frontend-seo
+{{- end }}

--- a/k8s/central-search-hub/templates/frontend_seo_renderer.yaml
+++ b/k8s/central-search-hub/templates/frontend_seo_renderer.yaml
@@ -2,16 +2,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-frontend-seo
+  name: {{ .Release.Name }}-frontend-seo-renderer
 spec:
   replicas: {{ .Values.frontend.seoRenderer.replicaCount }}
   selector:
     matchLabels:
-      name: {{ .Release.Name }}-frontend-seo
+      name: {{ .Release.Name }}-frontend-seo-renderer
   template:
     metadata:
       labels:
-        name: {{ .Release.Name }}-frontend-seo
+        name: {{ .Release.Name }}-frontend-seo-renderer
     spec:
       containers:
         - name: frontend-seo
@@ -24,6 +24,8 @@ spec:
               value: "3000"
             - name: INDEX_HTML_PATH
               value: "/app/build/index.html"
+            - name: DATAVERSE_API_BASE_URL
+              value: "http://{{ .Release.Name }}-backend:5000/api"
           readinessProbe:
             httpGet:
               path: /healthz
@@ -38,12 +40,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-frontend-seo
+  name: {{ .Release.Name }}-frontend-seo-renderer
 spec:
   ports:
     - name: http
       port: 3000
       targetPort: 3000
   selector:
-    name: {{ .Release.Name }}-frontend-seo
+    name: {{ .Release.Name }}-frontend-seo-renderer
 {{- end }}

--- a/k8s/central-search-hub/templates/frontend_seo_renderer.yaml
+++ b/k8s/central-search-hub/templates/frontend_seo_renderer.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.frontend.seoRenderer.enabled }}
+{{- if and .Values.frontend.seoRenderer.enabled (empty .Values.frontend.basicAuth.htpasswd) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/central-search-hub/templates/ingress.yaml
+++ b/k8s/central-search-hub/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: {{ .Release.Name }}-frontend-seo
+              name: {{ .Release.Name }}-frontend-seo-renderer
               port:
                 number: 3000
         - path: /

--- a/k8s/central-search-hub/templates/ingress.yaml
+++ b/k8s/central-search-hub/templates/ingress.yaml
@@ -23,13 +23,20 @@ spec:
     - host: {{ .Values.ingress.dns }}
       http:
         paths:
-        - path: /api/
+        - path: /api
           pathType: Prefix
           backend:
             service:
               name: {{ .Release.Name }}-backend
               port:
                 number: 5000
+        - path: /resource
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-frontend-seo
+              port:
+                number: 3000
         - path: /
           pathType: Prefix
           backend:

--- a/k8s/central-search-hub/templates/ingress.yaml
+++ b/k8s/central-search-hub/templates/ingress.yaml
@@ -30,6 +30,7 @@ spec:
               name: {{ .Release.Name }}-backend
               port:
                 number: 5000
+{{- if and .Values.frontend.seoRenderer.enabled (empty .Values.frontend.basicAuth.htpasswd) }}
         - path: /resource
           pathType: Prefix
           backend:
@@ -37,6 +38,7 @@ spec:
               name: {{ .Release.Name }}-frontend-seo-renderer
               port:
                 number: 3000
+{{- end }}
         - path: /
           pathType: Prefix
           backend:

--- a/k8s/central-search-hub/values.yaml
+++ b/k8s/central-search-hub/values.yaml
@@ -8,6 +8,15 @@ frontend:
   userback_access_token:
   basicAuth:
     htpasswd:
+  seoRenderer:
+    enabled: true
+    replicaCount: 1
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
 ingress:
   dns:
   enableSSL: false
@@ -25,3 +34,4 @@ oidc:
 images:
   backend: ghcr.io/nfdi4health/csh-ui/backend:dd54d34a33307e996407c426993b35fd44e08fb7
   frontend: ghcr.io/nfdi4health/csh-ui/frontend:dd54d34a33307e996407c426993b35fd44e08fb7
+  seoRenderer: ghcr.io/nfdi4health/csh-ui/frontend-seo:feat-1602-seo

--- a/k8s/central-search-hub/values.yaml
+++ b/k8s/central-search-hub/values.yaml
@@ -33,6 +33,6 @@ oidc:
     user_url:
     oidc_connect_url:
 images:
-  backend: ghcr.io/nfdi4health/csh-ui/backend:dd54d34a33307e996407c426993b35fd44e08fb7
-  frontend: ghcr.io/nfdi4health/csh-ui/frontend:dd54d34a33307e996407c426993b35fd44e08fb7
-  seoRenderer: ghcr.io/nfdi4health/csh-ui/frontend-seo:feat-1602-seo
+  backend: ghcr.io/nfdi4health/csh-ui/backend:master
+  frontend: ghcr.io/nfdi4health/csh-ui/frontend:master
+  seoRenderer: ghcr.io/nfdi4health/csh-ui/frontend-seo:master

--- a/k8s/central-search-hub/values.yaml
+++ b/k8s/central-search-hub/values.yaml
@@ -11,12 +11,13 @@ frontend:
   seoRenderer:
     enabled: true
     replicaCount: 1
-    requests:
-      cpu: 50m
-      memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 256Mi
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
 ingress:
   dns:
   enableSSL: false

--- a/k8s/cluster_config/csh-ing.yaml
+++ b/k8s/cluster_config/csh-ing.yaml
@@ -23,7 +23,7 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: csh-ui-blue-frontend-seo
+              name: csh-ui-blue-frontend-seo-renderer
               port:
                 number: 3000
         - path: /

--- a/k8s/cluster_config/csh-ing.yaml
+++ b/k8s/cluster_config/csh-ing.yaml
@@ -12,13 +12,20 @@ spec:
     - host: csh.nfdi4health.de
       http:
         paths:
-        - path: /api/
+        - path: /api
           pathType: Prefix
           backend:
             service:
               name: csh-ui-blue-backend
               port:
                 number: 5000
+        - path: /resource
+          pathType: Prefix
+          backend:
+            service:
+              name: csh-ui-blue-frontend-seo
+              port:
+                number: 3000
         - path: /
           pathType: Prefix
           backend:


### PR DESCRIPTION
## 📝 Description

Related to: https://github.com/nfdi4health/csh-ui/pull/1912

This PR adds the SEO renderer deployment to the Helm chart.

---

## 🔧 Changes

-
-
-

---

## ✅ Checklist

- [x] 📝 Version number in Helm's `Chart.yaml` was updated (if needed)
- [ ] 📚 Documentation was updated (if needed)
